### PR TITLE
Fix hardcoded path

### DIFF
--- a/examples/payload_example.xml
+++ b/examples/payload_example.xml
@@ -1,5 +1,5 @@
 <root>
-    <ConfigPath>/home/lorenzo/git/ExoRad2
+    <ConfigPath> .
         <comment>Main directory for the configuration files</comment>
     </ConfigPath>
     <fileName>payload_example</fileName>
@@ -7,7 +7,7 @@
         <sourceSpectrum>planck
             <comment>Source spectrum can be 'planck', 'phoenix' or 'custom'.
                 If it's 'planck', no more information are needed here.
-                If it's 'phoenix' the phoenix spectra directory must be indicated in "StellarModel".
+                If it's 'phoenix' the phoenix spectra directory must be indicated in "StellarModels".
                 if it's 'custom' the custom Sed file must be indicated in "CustomSed".
             </comment>
             <StellarModels>/usr/local/project_data/sed
@@ -252,14 +252,3 @@
         </detector>
     </channel>
 </root>
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
`ConfigPath` now points to the current directory by default so the example commands will work.
However, the `StellarModels` path is still hardcoded to `/usr/local/project_data/sed`.